### PR TITLE
Database persistence

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
       POSTGRES_PASSWORD: root
       POSTGRES_USER: root
       POSTGRES_DB: laravel
+    volumes:
+      - ./database:/var/lib/postgresql/data
 
   adminer:
     container_name: adminer

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ stop:
 	docker-compose down --volumes --remove-orphans
 
 shell: start
-	docker-compose exec -u 1000:1000 php bash
+	docker-compose exec php bash
 
 update: stop
 	git pull origin master

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,7 +1,10 @@
 FROM php:fpm
 
+RUN useradd -u 1000 -m php
 RUN apt-get update && apt-get install --yes libpq-dev
 RUN docker-php-ext-install pgsql pdo_pgsql
 RUN sed -i 's/\(listen =\).*/\1 0.0.0.0:9000/' /usr/local/etc/php-fpm.d/www.conf
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN sed -i 's/\(expose_php =\) On/\1 Off/' "$PHP_INI_DIR/php.ini"
+
+USER php


### PR DESCRIPTION
This pull request should close #1.

Changelog:

- [x] The user definition in the `makefile` has been removed.
- [x] The user `php` is now created and used in the proper `Dockerfile` for PHP which allows the use of a named user in the shell and preventing writing errors from vendor packages for instance.
- [x] The database persistence is now in place and allows to safely stop the container and shutdown the computer without losing the database informations stored.