### PR TITLE
Ubuntu conflicting port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,6 @@ services:
   postgres:
     container_name: postgres
     image: postgres
-    ports:
-      - 5432:5432
     environment:
       POSTGRES_PASSWORD: root
       POSTGRES_USER: root

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,6 @@ services:
     container_name: php
     build: php
     working_dir: /usr/share/nginx/html
-    ports:
-      - 9000:9000
     volumes:
       - ./laravel:/usr/share/nginx/html
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,9 +1,10 @@
 FROM php:fpm
 
+RUN useradd -u 1000 -m php
 RUN apt-get update && apt-get install --yes libpq-dev
 RUN docker-php-ext-install pgsql pdo_pgsql
 RUN sed -i 's/\(listen =\).*/\1 0.0.0.0:9000/' /usr/local/etc/php-fpm.d/www.conf
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN sed -i 's/\(expose_php =\) On/\1 Off/' "$PHP_INI_DIR/php.ini"
 
-USER www-data
+USER php:www-data

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,10 +1,9 @@
 FROM php:fpm
 
-RUN useradd -u 1000 -m php
 RUN apt-get update && apt-get install --yes libpq-dev
 RUN docker-php-ext-install pgsql pdo_pgsql
 RUN sed -i 's/\(listen =\).*/\1 0.0.0.0:9000/' /usr/local/etc/php-fpm.d/www.conf
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN sed -i 's/\(expose_php =\) On/\1 Off/' "$PHP_INI_DIR/php.ini"
 
-USER php
+USER www-data


### PR DESCRIPTION
This should close #2.

- [x] Unecessary public exposed ports for postgres & php-fpm have been removed in order to preventing further conflicts with other userland applications.
- [x] Created a `php` user and allowing the `www-data` make sure that the `www-data` and `php` users are able to read/write files in the `laravel` folders.